### PR TITLE
Add Support for AMD/RequireJS

### DIFF
--- a/thumbs.js
+++ b/thumbs.js
@@ -12,7 +12,7 @@
     if (typeof exports !== 'undefined') {
         thumbs = exports;
     } else if (typeof define === "function" && define.amd) {
-        define(function () { 
+        define(function () {
             thumbs = {};
             return thumbs;
         });

--- a/thumbs.js
+++ b/thumbs.js
@@ -11,6 +11,11 @@
     var thumbs;
     if (typeof exports !== 'undefined') {
         thumbs = exports;
+    } else if (typeof define === "function" && define.amd) {
+        define(function () { 
+            thumbs = {};
+            return thumbs;
+        });
     } else {
         thumbs = root.thumbs = {};
     }
@@ -412,8 +417,5 @@
             return this.renderTemplate()._super("render", arguments);
         }
     });
-
-    return View;
-
 
 }).call(this);


### PR DESCRIPTION
If AMD is supported on the page, I don't export thumbs as a global. Instead it is defined the AMD way.
