### PR TITLE
Updated history spec to pass with latest Backbone

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -33,7 +33,7 @@ module.exports = function (grunt) {
                     'test/helpers.js'
                 ],
                 vendor: [
-                    'components/jquery/jquery.js',
+                    'components/jquery/dist/jquery.js',
                     'components/underscore/underscore.js',
                     'components/backbone/backbone.js'
                 ]

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "thumbs",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "main": "thumbs.js",
   "author": "Pollenware",
   "ignore": [
@@ -9,9 +9,9 @@
     "components"
   ],
   "dependencies": {
-    "jquery": "~1.8.3",
-    "backbone": "1.1.0",
-    "underscore": "~1.5.2"
+    "jquery": "~1.11.1",
+    "backbone": "1.1.2",
+    "underscore": "~1.6.0"
   },
   "devDependencies": {
     "sinon": "http://sinonjs.org/releases/sinon-1.5.2.js",

--- a/test/runner.html
+++ b/test/runner.html
@@ -8,7 +8,7 @@
 
 
         <!-- load required test libraries -->
-        <script type="text/javascript" src="../components/jquery/jquery.js"></script>
+        <script type="text/javascript" src="../components/jquery/dist/jquery.js"></script>
         <script type="text/javascript" src="../components/underscore/underscore.js"></script>
         <script type="text/javascript" src="../components/backbone/backbone.js"></script>
 

--- a/test/spec/history.spec.js
+++ b/test/spec/history.spec.js
@@ -67,7 +67,7 @@ describe("Thumbs.History", function() {
         this.router.navigate('', {trigger: true});
 
         expect(routerSpy).toHaveBeenCalledOnce();
-        expect(routerSpy).toHaveBeenCalledWithExactly();
+        expect(routerSpy).toHaveBeenCalledWith(null);
 
         expect(starPreRoute).toHaveBeenCalledOnce();
         expect(starPreRoute).toHaveBeenCalledWithExactly();
@@ -86,7 +86,7 @@ describe("Thumbs.History", function() {
         this.router.navigate('route/one', {trigger: true});
 
         expect(routerSpy).toHaveBeenCalledOnce();
-        expect(routerSpy).toHaveBeenCalledWithExactly();
+        expect(routerSpy).toHaveBeenCalledWithExactly(null);
 
         expect(starPreRoute).toHaveBeenCalledOnce();
         expect(starPreRoute).toHaveBeenCalledWithExactly();
@@ -111,7 +111,7 @@ describe("Thumbs.History", function() {
         this.router.navigate('route2/12/34', {trigger: true});
 
         expect(routerSpy).toHaveBeenCalledOnce();
-        expect(routerSpy).toHaveBeenCalledWithExactly("12", "34");
+        expect(routerSpy).toHaveBeenCalledWithExactly('12', '34', null);
 
         expect(starPreRoute).toHaveBeenCalledOnce();
         expect(starPreRoute).toHaveBeenCalledWithExactly();
@@ -127,6 +127,16 @@ describe("Thumbs.History", function() {
         expect(specificPreRoute2.calledBefore(routerSpy)).toBe(true);
 
         expect(unmatchedPreRoute).toHaveNotBeenCalled();
+    });
+
+    it('should pass query param in to the handler as the last argument', function() {
+        var routerSpy = spies.router;
+
+        this.router.bind('route:routeTwo', routerSpy, this);
+        this.router.navigate('route2/12/34?query', {trigger: true});
+
+        expect(routerSpy).toHaveBeenCalledOnce();
+        expect(routerSpy).toHaveBeenCalledWithExactly('12', '34', 'query');
     });
 
     it('should stop navigation if preRoute returns "false"', function() {


### PR DESCRIPTION
Updated history spec to pass with Backbone 1.1.1's change to pass query params in route fragments as the last argument to the handler and to use latest Underscore and jQuery. 

From the Backbone change log on 1.1.1:
`Backbone Routers now handle query params in route fragments, passing them into the handler as the last argument. Routes specified as strings should no longer include the query string ('foo?:query' should be 'foo').`
